### PR TITLE
Add Linear project name to synced fields

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -72,6 +72,9 @@ export default class Setup extends Command {
             }),
           },
         },
+        Project: {
+          rich_text: {},
+        },
         Priority: {
           select: {
             options: [

--- a/src/sync/sync.ts
+++ b/src/sync/sync.ts
@@ -21,6 +21,7 @@ export class LinearNotionSync {
   private async getProperties(issue: Issue, state: WorkflowState) {
     const statusName = state?.name
     const assignee = await issue.assignee?.then((s: any) => s.name)
+    const project = await issue.project?.then((p: any) => p.name) || ''
 
     return {
       Title: {
@@ -65,6 +66,17 @@ export class LinearNotionSync {
         select: {
           name: statusName,
         },
+      },
+      Project: {
+        type: 'rich_text',
+        rich_text: [
+          {
+            type: 'text',
+            text: {
+              content: project,
+            },
+          },
+        ],
       },
       Priority: {
         type: 'select',


### PR DESCRIPTION
Our team needed the Project name field from Linear in Notion, so we added it. This will only work with new databases created with Setup, so it's up to you whether you'd like to merge or not.